### PR TITLE
Build improvements, align case expression in chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,303 @@
+## Core latex/pdflatex auxiliary files:
+*.aux
+*.lof
+*.log
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Build tool directories for auxiliary files
+# latexrun
+latex.out/
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# comment
+*.cut
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+*.lzo
+*.lzs
+*.slg
+*.slo
+*.sls
+
+# uncomment this for glossaries-extra (will ignore makeindex's style files!)
+# *.ist
+
+# gnuplot
+*.gnuplot
+*.table
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.glog
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Uncomment the next line if you use knitr and want to ignore its generated tikz files
+# *.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# luatexja-ruby
+*.ltjruby
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# newpax
+*.newpax
+
+# nomencl
+*.nlg
+*.nlo
+*.nls
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# svg
+svg-inkscape/
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# tcolorbox
+*.listing
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# titletoc
+*.ptc
+
+# todonotes
+*.tdo
+
+# vhistory
+*.hst
+*.ver
+
+# easy-todo
+*.lod
+
+# xcolor
+*.xcp
+
+# xmpincl
+*.xmpi
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices and outlines
+*.xyc
+*.xyd
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# LyX
+*.lyx~
+
+# Kile
+*.backup
+
+# gummi
+.*.swp
+
+# KBibTeX
+*~[0-9]*
+
+# TeXnicCenter
+*.tps
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta
+
+# Makeindex log files
+*.lpz
+
+# xwatermark package
+*.xwm
+
+# REVTeX puts footnotes in the bibliography by default, unless the nofootinbib
+# option is specified. Footnotes are the stored in a file with suffix Notes.bib.
+# Uncomment the next line to have this generated file ignored.
+#*Notes.bib
+
+chart.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: clean all
+
+all:
+	latexmk -pdflatex="texfot pdflatex" -pdf chart.tex
+
+clean:
+	latexmk -c

--- a/chart.tex
+++ b/chart.tex
@@ -11,7 +11,7 @@
 \usepackage{amsmath,amssymb,amsthm,mathtools,stmaryrd}
 \usepackage{proof,mathpartir}
 \usepackage{colonequals}
-\usepackage{code,verbatim}
+\usepackage{verbatim}
 \usepackage{comment}
 \usepackage{textcomp}
 \usepackage[us]{optional}
@@ -63,7 +63,7 @@ Answer type:
   \begin{array}{l@{\quad}l@{\quad}l}
     \ansty & \ansty* \\
     \yesex & \yesex* \\
-    \noex & \noex*  
+    \noex & \noex*
   \end{array}
 \end{displaymath}
 
@@ -91,7 +91,7 @@ Basic types:
 
     \sumty{\tau_1}{\tau_2} & \sumty*{\tau_1}{\tau_2} \\
     \injex<i>[\tau_1][\tau_2]{e} & \injex*<i>{e} & (i=\kw{1},\kw{2}) \\
-    \caseex[\rho][\tau]{e}{x}{e'} & \multicolumn{2}{l}{\caseex*{e}{x}{e'}}   % implicitly indexed branches
+    \caseex[\rho][\tau]{e}{x}{e'} & \multicolumn{2}{l}{\!\!\!\caseex*{e}{x}{e'}}   % implicitly indexed branches
 
   \end{array}
 \end{displaymath}
@@ -105,7 +105,7 @@ Variadic forms:\footnote{All operators are indexed by finite sets $I$ of constan
 
     \vsumty<I><i>{\tau}  & \vsumty*<I><i>{\tau} \\
     \vinjex<I><i>[\tau]{e} & \vinjex*<I><i>{e} & (i\in I) \\
-    \vcaseex<I>[\rho][\tau]{e}{x}{e'}  & \vcaseex*<I>{e}{x}{e'} 
+    \vcaseex<I>[\rho][\tau]{e}{x}{e'}  & \vcaseex*<I>{e}{x}{e'}
   \end{array}
 \end{displaymath}
 
@@ -169,7 +169,7 @@ Commands:\footnote{Symbols $a$ are constants of sort $\kw{loc}$.}
     \getcmd{a} & \getcmd*{a} \\
     \getrefcmd[\tau]{e} & \getrefcmd*{e} \\
     \setcmd{a}{e} & \setcmd*{a}{e} \\
-    \setrefcmd[\tau]{e_1}{e_2} & \setrefcmd*[\tau]{e_1}{e_2} 
+    \setrefcmd[\tau]{e_1}{e_2} & \setrefcmd*[\tau]{e_1}{e_2}
  \end{array}
 \end{displaymath}
 


### PR DESCRIPTION
Hi Bob

This chart is pretty helpful, thanks for putting it out here. I noticed `code.sty` was missing in the repo but is perhaps not needed.

This PR includes the following changes:
- Remove unneeded code.sty
- fix alignment of case expression
- add a gitignore
- add Makefile that uses `latexmk`