### PR TITLE
Include required package

### DIFF
--- a/pfpl-syntax.sty
+++ b/pfpl-syntax.sty
@@ -1,6 +1,7 @@
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{pfpl-syntax}[2022/01/15 1.0.0 PFPL Syntax Macros]
 \RequirePackage{amsmath,amssymb,amsthm,mathtools,stmaryrd,bigplustimes}
+\RequirePackage{xifthen}
 
 % camel case is used for internal macros in the vain hope to avoid conflicts.
 % latex desperately needs sensible scoping of identifiers!


### PR DESCRIPTION
Without this change, I get the following error when trying to use the style file in my own project:
```
./pfpl-syntax.sty:14: Undefined control sequence: 
l.14 \newboolean
                {opnidx}\setboolean{opnidx}{false}  % typeset operator indic...
The control sequence at the end of the top line
of your error message was never \def'ed. If you have
misspelled it (e.g., `\hobx'), type `I' and the correct
spelling (e.g., `I\hbox'). Otherwise just continue,
and I'll forget about whatever was undefined.
```