### PR TITLE
Fix arguments for concrete syntax of bndCmd

### DIFF
--- a/pfpl-syntax.sty
+++ b/pfpl-syntax.sty
@@ -158,7 +158,7 @@
 \NewDocumentCommand{\dclcmd}{s O{\tau} m O{\rho} m m}{\IfBooleanTF{#1}{\dclCst{#2}{#3}{#5}{#6}}{\dclAbt{#2}{#4}{#3}{\Abs<#5>{#6}}}}
 
 \NewDocumentCommand{\bndAbt}{m m m m m}{\Abt{\Opn{bnd}}[#1\sep  #2]{#3\sep  \Abs(#4){#5}}}
-\NewDocumentCommand{\bndCst}{m m m m}{\Opn{bnd}_{#1}\,#2\mathbin{\leftarrow}#1\mathbin{\kw{;}}#3}
+\NewDocumentCommand{\bndCst}{m m m m}{\Opn{bnd}_{#1}\,#3\mathbin{\leftarrow}#2\mathbin{\kw{;}}#4}
 \NewDocumentCommand{\bndcmd}{s O{\tau} m O{\rho} m m}{\IfBooleanTF{#1}{\bndCst{#4}{#3}{#5}{#6}}{\bndAbt{#2}{#4}{#3}{#5}{#6}}}
 
 % reference types


### PR DESCRIPTION
Current:

<img width="418" alt="Screen Shot 2022-04-20 at 3 34 15 PM" src="https://user-images.githubusercontent.com/374340/164318115-d318be43-6a85-4cbe-a495-e85cdb08e668.png">

After this change:

<img width="427" alt="Screen Shot 2022-04-20 at 3 34 52 PM" src="https://user-images.githubusercontent.com/374340/164318199-cbf387b6-9305-4a7c-a30a-f35d2a4ee790.png">

